### PR TITLE
Je support otp 21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+*Currently no unreleased changes*
+
+## [0.4.4] - 2018-12-14
+### Added
+- This changelog!
+
+### Changed
+- Added support in vm stats for OTP21 logging in order to provide the number of `error`-level log messages in the logging queue.  Support for `:error_logger` is maintained

--- a/lib/stats_doggo/vmstats.ex
+++ b/lib/stats_doggo/vmstats.ex
@@ -1,6 +1,5 @@
 defmodule StatsDoggo.Vmstats do
   use GenServer
-  require Logger
 
   @moduledoc """
   StatsDoggo.Vmstats is a GenServer that periodically records BEAM virtual machine statistics to

--- a/lib/stats_doggo/vmstats.ex
+++ b/lib/stats_doggo/vmstats.ex
@@ -78,10 +78,10 @@ defmodule StatsDoggo.Vmstats do
         :erlang.system_flag(:scheduler_wall_time, true)
       else
         _ -> true
-      catch
-        _ -> true
       rescue
         ArgumentError -> false
+      catch
+        _ -> true
       end
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule StatsDoggo.Mixfile do
   use Mix.Project
 
   @name    :stats_doggo
-  @version "0.4.3"
+  @version "0.4.4"
 
   @deps [
     {:env_config, ">= 0.1.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,13 @@
-%{"earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
-  "env_config": {:hex, :env_config, "0.1.0", "7ff17696787ff15ca59358d4770d32fe628eb06c46fa4682c009562388debdd2", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+%{
+  "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
+  "env_config": {:hex, :env_config, "0.2.0", "d12640aa1cff012803e51f9be25f9a6c420c717d0da2bf9b3495cc039ad802b1", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "ex_vmstats": {:git, "https://github.com/dplummer/ex_vmstats.git", "318789bb401105b79a9deb9750481cce8b9797c0", [branch: "worker-config"]},
+  "makeup": {:hex, :makeup, "0.5.6", "da47b331b1fe0a5f0380cc3a6967200eac5e1daaa9c6bff4b0310b3fcc12b98f", [:mix], [{:nimble_parsec, "~> 0.4.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], [], "hexpm"},
-  "plug": {:hex, :plug, "1.3.5", "7503bfcd7091df2a9761ef8cecea666d1f2cc454cbbaf0afa0b6e259203b7031", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
-  "statix": {:hex, :statix, "1.0.0", "836c0752ad2b568dcdc9b1e67df0df91ad491ea1e19965ac219a9a0569e7e338", [:mix], [], "hexpm"}}
+  "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm"},
+  "plug": {:hex, :plug, "1.7.1", "8516d565fb84a6a8b2ca722e74e2cd25ca0fc9d64f364ec9dbec09d33eb78ccd", [:mix], [{:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.0", [hex: :plug_crypto, repo: "hexpm", optional: false]}], "hexpm"},
+  "plug_crypto": {:hex, :plug_crypto, "1.0.0", "18e49317d3fa343f24620ed22795ec29d4a5e602d52d1513ccea0b07d8ea7d4d", [:mix], [], "hexpm"},
+  "statix": {:hex, :statix, "1.1.0", "af9a4586c5cd58f879e0595f06a4790878715de5b8f75f6346693aaa38da2424", [:mix], [], "hexpm"},
+}

--- a/test/vm_stats_test.exs
+++ b/test/vm_stats_test.exs
@@ -1,0 +1,18 @@
+defmodule VmStatsTest do
+  use ExUnit.Case, async: true
+
+  setup do
+    stats_server_pid = start_supervised!(StatsDoggo.Vmstats)
+    %{stats_server_pid: stats_server_pid}
+  end
+
+  test "does not crash on pre-otp21 error queue length", %{stats_server_pid: stats_server_pid} do
+    :error_logger.add_report_handler(:error_handler)
+
+    send(stats_server_pid, {:timeout, "ref", :interval_elapsed})
+  end
+
+  test "does not crash on OTP21 logger error message queue length", %{stats_server_pid: stats_server_pid} do
+    send(stats_server_pid, {:timeout, "ref", :interval_elapsed})
+  end
+end


### PR DESCRIPTION
#What
OTP21 which is required by versions of elixir later than 1.6 deprecates the `:error_logger` application in favor of a whole new `logger` api.

This change supports both strategies for determining how many queued log messages you have for the `error` level in `vm stats`

If you try to run a project that depends on stats_doggo on the elixir 1.7 runtime you'll get an error.